### PR TITLE
Removed shop from main menu options

### DIFF
--- a/Client/src/view/MainMenu.java
+++ b/Client/src/view/MainMenu.java
@@ -32,7 +32,8 @@ public class MainMenu extends Show {
     private final MenuItem[] itemsArray = {
             new MenuItem(itemIndex++, "PLAY", "Single player, multiplayer", event -> PlayMenu.getInstance().show()),
             new MenuItem(itemIndex++, "PROFILE", "See you profile information", event -> menu.showProfileDialog()),
-            new MenuItem(itemIndex++, "SHOP", "Buy or sell every card you want", event -> new ShopMenu().show()),
+            //disabled for now. General consensus is that we do not want it
+            //new MenuItem(itemIndex++, "SHOP", "Buy or sell every card you want", event -> new ShopMenu().show()),
             new MenuItem(itemIndex++, "COLLECTION", "View your cards or build a deck", event -> new CollectionMenu().show()),
             new MenuItem(itemIndex++, "CUSTOM CARD", "Design your card with your own taste", event -> new CustomCardMenu().show()),
             new MenuItem(itemIndex++, "GLOBAL CHAT", "chat with other players", event -> GlobalChatDialog.getInstance().show()),


### PR DESCRIPTION
In a previous commit, we added in the feature that gives all users 3 copies of each card upon regirstration, so all that is left is to remove the shop from the main menu.