### PR TITLE
Add Maven Workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,8 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 1.8.0
+        java-package: jre 8.0
+        architecture: x64
     - name: Build with Maven
       run: mvn -B clean package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8.0
-        java-package: jre 8.0
+        java-package: jdk+fx
         architecture: x64
     - name: Build with Maven
       run: mvn -B clean package --file pom.xml


### PR DESCRIPTION
Bit of an experiment (never tried this before), but I think this change means that the code will automatically be built when we push a branch. 

If maven can build (i.e. mvm clean package does not fail) the check passes.

Hopefully this would reduce the risk of us committing broken code to master.