### PR TITLE
Add flame blood warlock

### DIFF
--- a/Server/resources/accounts/john_doe.account.json
+++ b/Server/resources/accounts/john_doe.account.json
@@ -405,7 +405,55 @@
         "remainingNumber": 20
       }
     ],
+	
     "minions": [
+		{
+			"name": "Flameblood Warlock",
+			"description": "Opening Gambit: Deal 3 damage to both generals",
+			"cardId": "johndoe_FlamebloodWarlock_1",
+			"spriteName": "neutral_mercflamebloodwarlock",
+			"type": "MINION",
+			"spells": [{
+					"spellId": "deal_3_to_generals",
+					"action": {
+						"hpChange": -3,
+						"durable": true,
+						"duration": 1
+					},
+					"target": {
+						"isRelatedToCardOwnerPosition": true,
+						"dimensions": {
+							"row": 10,
+							"column": 18
+						},
+
+						"owner": {
+							"own": true,
+							"enemy": true
+						},
+
+						"cardType": {
+							"hero": true
+						},
+
+						"attackType": {
+							"melee": true,
+							"ranged": true,
+							"hybrid": true
+						}
+					},
+					"availabilityType": {
+						"onPut": true
+					}
+			}],
+			"defaultAp": 3,
+			"defaultHp": 1,
+			"mannaPoint": 3,
+			"price": 100,
+			"attackType": "MELEE",
+			"remainingNumber": 20
+		},
+	
       {
         "name": "Arjang The Demon",
         "description": "a melee MINION with 6 AP, 6 HP, can attack combo",

--- a/Server/resources/accounts/john_doe.account.json
+++ b/Server/resources/accounts/john_doe.account.json
@@ -448,7 +448,7 @@
 			}],
 			"defaultAp": 3,
 			"defaultHp": 1,
-			"mannaPoint": 3,
+			"mannaPoint": 2,
 			"price": 100,
 			"attackType": "MELEE",
 			"remainingNumber": 20

--- a/Server/resources/minionCards/FlamebloodWarlock.minion.card.json
+++ b/Server/resources/minionCards/FlamebloodWarlock.minion.card.json
@@ -1,0 +1,46 @@
+{
+	"name": "Flameblood Warlock",
+	"description": "Opening Gambit: Deal 3 damage to both generals",
+	"cardId": "FlamebloodWarlock",
+	"spriteName": "neutral_mercflamebloodwarlock",
+	"type": "MINION",
+	"spells": [{
+			"spellId": "deal_3_to_generals",
+			"action": {
+				"hpChange": -3,
+				"durable": true,
+				"duration": 1
+			},
+			"target": {
+				"isRelatedToCardOwnerPosition": true,
+				"dimensions": {
+					"row": 10,
+					"column": 18
+				},
+
+				"owner": {
+					"own": true,
+					"enemy": true
+				},
+
+				"cardType": {
+					"hero": true
+				},
+
+				"attackType": {
+					"melee": true,
+					"ranged": true,
+					"hybrid": true
+				}
+			},
+			"availabilityType": {
+				"onPut": true
+			}
+	}],
+	"defaultAp": 3,
+	"defaultHp": 1,
+	"mannaPoint": 3,
+	"price": 100,
+	"attackType": "MELEE",
+	"remainingNumber": 20
+}

--- a/Server/resources/minionCards/FlamebloodWarlock.minion.card.json
+++ b/Server/resources/minionCards/FlamebloodWarlock.minion.card.json
@@ -39,7 +39,7 @@
 	}],
 	"defaultAp": 3,
 	"defaultHp": 1,
-	"mannaPoint": 3,
+	"mannaPoint": 2,
 	"price": 100,
 	"attackType": "MELEE",
 	"remainingNumber": 20

--- a/resources/minionCards/FlamebloodWarlock.minion.card.json
+++ b/resources/minionCards/FlamebloodWarlock.minion.card.json
@@ -1,0 +1,46 @@
+{
+	"name": "Flameblood Warlock",
+	"description": "Opening Gambit: Deal 3 damage to both generals",
+	"cardId": "FlamebloodWarlock",
+	"spriteName": "neutral_mercflamebloodwarlock",
+	"type": "MINION",
+	"spells": [{
+			"spellId": "deal_3_to_generals",
+			"action": {
+				"hpChange": -3,
+				"durable": true,
+				"duration": 1
+			},
+			"target": {
+				"isRelatedToCardOwnerPosition": true,
+				"dimensions": {
+					"row": 10,
+					"column": 18
+				},
+
+				"owner": {
+					"own": true,
+					"enemy": true
+				},
+
+				"cardType": {
+					"hero": true
+				},
+
+				"attackType": {
+					"melee": true,
+					"ranged": true,
+					"hybrid": true
+				}
+			},
+			"availabilityType": {
+				"onPut": true
+			}
+	}],
+	"defaultAp": 3,
+	"defaultHp": 1,
+	"mannaPoint": 3,
+	"price": 100,
+	"attackType": "MELEE",
+	"remainingNumber": 20
+}

--- a/resources/minionCards/FlamebloodWarlock.minion.card.json
+++ b/resources/minionCards/FlamebloodWarlock.minion.card.json
@@ -39,7 +39,7 @@
 	}],
 	"defaultAp": 3,
 	"defaultHp": 1,
-	"mannaPoint": 3,
+	"mannaPoint": 2,
 	"price": 100,
 	"attackType": "MELEE",
 	"remainingNumber": 20


### PR DESCRIPTION
Adds Flameblood Warlock card to the game.
2 mana 3/1 Opening Gambit: Deal 3 to both Generals.

Added Card to John Doe account.

Todo figure out a way to give John Doe 3x copies.

Playtested