### PR TITLE
Add two generals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,7 @@ buildNumber.properties
 
 /exported_decks/*
 
-/Server/resources/heroCards/
+!Server/resources/heroCards/
 /Server/resources/itemCards/
 /Server/resources/minionCards/
 /Server/resources/spellCards/

--- a/Client/resources/troopAnimations/f1_general.plist.json
+++ b/Client/resources/troopAnimations/f1_general.plist.json
@@ -3,7 +3,7 @@
   "frameHeight": 100,
   "frameDuration": 100,
   "extraX": 75.0,
-  "extraY": 75.0,
+  "extraY": 125.0,
   "lists": {
     "hit": [
       {

--- a/Server/resources/accounts/john_doe.account.json
+++ b/Server/resources/accounts/john_doe.account.json
@@ -4,8 +4,8 @@
   "accountType": "NORMAL",
   "collection": {
     "heroes": [
-      {
-		  {
+	
+		{
 		  "name": "Argeon Highmayne",
 		  "description": "Lyonar General",
 		  "cardId": "johndoe_ArgeonHighmayne_1",
@@ -39,6 +39,7 @@
 		  "remainingNumber": 20
 		},
 	  
+	    {
         "name": "Afsaaneh",
         "description": "a ranged HERO with 3 AP, 40 HP, have a DISPEL spell",
         "cardId": "johndoe_Afsaaneh_1",
@@ -439,7 +440,9 @@
         "remainingNumber": 20
       }
     ],
+	
     "minions": [
+		
       {
         "name": "Arjang The Demon",
         "description": "a melee MINION with 6 AP, 6 HP, can attack combo",

--- a/Server/resources/accounts/john_doe.account.json
+++ b/Server/resources/accounts/john_doe.account.json
@@ -5,6 +5,40 @@
   "collection": {
     "heroes": [
       {
+		  {
+		  "name": "Argeon Highmayne",
+		  "description": "Lyonar General",
+		  "cardId": "johndoe_ArgeonHighmayne_1",
+		  "spriteName": "f1_general",
+		  "type": "HERO",
+		  "spells": [],
+		  "defaultAp": 2,
+		  "defaultHp": 25,
+		  "mannaPoint": 0,
+		  "price": 10,
+		  "attackType": "MELEE",
+		  "range": 0,
+		  "hasCombo": false,
+		  "remainingNumber": 20
+		},
+		
+		{
+		  "name": "Vaath The Immortal",
+		  "description": "Magmar General",
+		  "cardId": "johndoe_VaathTheImmortal_1",
+		  "spriteName": "f5_general",
+		  "type": "HERO",
+		  "spells": [],
+		  "defaultAp": 2,
+		  "defaultHp": 25,
+		  "mannaPoint": 0,
+		  "price": 10,
+		  "attackType": "MELEE",
+		  "range": 0,
+		  "hasCombo": false,
+		  "remainingNumber": 20
+		},
+	  
         "name": "Afsaaneh",
         "description": "a ranged HERO with 3 AP, 40 HP, have a DISPEL spell",
         "cardId": "johndoe_Afsaaneh_1",

--- a/Server/resources/heroCards/ArgeonHighmayne.hero.card.json
+++ b/Server/resources/heroCards/ArgeonHighmayne.hero.card.json
@@ -1,0 +1,16 @@
+{
+  "name": "Argeon Highmayne",
+  "description": "Lyonar General",
+  "cardId": "ArgeonHighmayne",
+  "spriteName": "f1_general",
+  "type": "HERO",
+  "spells": [],
+  "defaultAp": 2,
+  "defaultHp": 25,
+  "mannaPoint": 0,
+  "price": 10,
+  "attackType": "MELEE",
+  "range": 0,
+  "hasCombo": false,
+  "remainingNumber": 20
+}

--- a/Server/resources/heroCards/VaathTheImmortal.hero.card.json
+++ b/Server/resources/heroCards/VaathTheImmortal.hero.card.json
@@ -1,0 +1,16 @@
+{
+  "name": "Vaath The Immortal",
+  "description": "Magmar General",
+  "cardId": "VaathTheImmortal",
+  "spriteName": "f5_general",
+  "type": "HERO",
+  "spells": [],
+  "defaultAp": 2,
+  "defaultHp": 25,
+  "mannaPoint": 0,
+  "price": 10,
+  "attackType": "MELEE",
+  "range": 0,
+  "hasCombo": false,
+  "remainingNumber": 20
+}

--- a/resources/heroCards/ArgeonHighmayne.hero.card.json
+++ b/resources/heroCards/ArgeonHighmayne.hero.card.json
@@ -1,0 +1,16 @@
+{
+  "name": "Argeon Highmayne",
+  "description": "Lyonar General",
+  "cardId": "ArgeonHighmayne",
+  "spriteName": "f1_general",
+  "type": "HERO",
+  "spells": [],
+  "defaultAp": 2,
+  "defaultHp": 25,
+  "mannaPoint": 0,
+  "price": 10,
+  "attackType": "MELEE",
+  "range": 0,
+  "hasCombo": false,
+  "remainingNumber": 20
+}

--- a/resources/heroCards/VaathTheImmortal.hero.card.json
+++ b/resources/heroCards/VaathTheImmortal.hero.card.json
@@ -1,0 +1,16 @@
+{
+  "name": "Vaath The Immortal",
+  "description": "Magmar General",
+  "cardId": "VaathTheImmortal",
+  "spriteName": "f5_general",
+  "type": "HERO",
+  "spells": [],
+  "defaultAp": 2,
+  "defaultHp": 25,
+  "mannaPoint": 0,
+  "price": 10,
+  "attackType": "MELEE",
+  "range": 0,
+  "hasCombo": false,
+  "remainingNumber": 20
+}


### PR DESCRIPTION
Argeon and Vaath are now playable Hero's.

2/25 (no BBS)

Added Generals to John Doe account

Added as a single branch because the generals are basically the same.