### PR TITLE
Remove deck requirement item

### DIFF
--- a/Client/src/models/card/Deck.java
+++ b/Client/src/models/card/Deck.java
@@ -81,7 +81,7 @@ public class Deck {
     }
 
     public boolean isValid() {
-        if (hero == null || item == null) return false;
+        if (hero == null) return false;
         return others.size() == 20;
     }
 

--- a/Server/resources/accounts/john_doe.account.json
+++ b/Server/resources/accounts/john_doe.account.json
@@ -7529,7 +7529,7 @@
         "remainingNumber": 20
       }
     ],
-    "items": [
+    "items": [		
       {
         "name": "Assassination Dagger",
         "description": "TODO",
@@ -9273,7 +9273,6 @@
     {
       "deckName": "deck",
       "heroId": "johndoe_SevenHeadedDragon_1",
-      "itemId": "johndoe_CrownOfWisdom_1",
       "othersIds": [
         "johndoe_ArjangTheDemon_1",
         "johndoe_ArjangTheDemon_2",
@@ -9300,7 +9299,6 @@
     {
       "deckName": "Prebuilt Deck 1",
       "heroId": "johndoe_Afsaaneh_1",
-      "itemId": "johndoe_CrownOfWisdom_1",
       "othersIds": [
         "johndoe_ArjangTheDemon_1",
         "johndoe_ArjangTheDemon_2",

--- a/Server/src/server/dataCenter/models/card/Deck.java
+++ b/Server/src/server/dataCenter/models/card/Deck.java
@@ -106,7 +106,7 @@ public class Deck {
     }
 
     public boolean isValid() {
-        if (hero == null || item == null) return false;
+        if (hero == null) return false;
         return others.size() == 20;
     }
 

--- a/Server/src/server/gameCenter/models/game/Player.java
+++ b/Server/src/server/gameCenter/models/game/Player.java
@@ -1,5 +1,6 @@
 package server.gameCenter.models.game;
 
+import server.Server;
 import server.clientPortal.models.comperessedData.CompressedCard;
 import server.clientPortal.models.comperessedData.CompressedPlayer;
 import server.dataCenter.models.account.MatchHistory;
@@ -38,8 +39,15 @@ public class Player {
     }
 
     public CompressedPlayer toCompressedPlayer() {
+        Card firstItem = deck.getItem();
+        CompressedCard useableItem = null;
+
+        if (firstItem != null){
+            useableItem = firstItem.toCompressedCard();
+        }
+
         return new CompressedPlayer(
-                userName, currentMP, hand, graveyard, nextCard,deck.getItem().toCompressedCard(), collectedItems, playerNumber, numberOfCollectedFlags);
+                userName, currentMP, hand, graveyard, nextCard, useableItem , collectedItems, playerNumber, numberOfCollectedFlags);
     }
 
     public List<Card> getHand() {


### PR DESCRIPTION
- Decks no longer need 1 item in order to be valid.
- Fixed a bad practice where function call was in return statement.  (Now handles null case).
- Removed item from john doe starter decks
- Light playtesting.

