### PR TITLE
Add server side logout

### DIFF
--- a/Server/src/server/GameEndpoint.java
+++ b/Server/src/server/GameEndpoint.java
@@ -3,11 +3,10 @@ package server;
 import server.clientPortal.ClientPortal;
 import server.clientPortal.models.message.Message;
 import server.dataCenter.DataCenter;
+import server.exceptions.LogicException;
 
 import javax.websocket.*;
 import javax.websocket.server.ServerEndpoint;
-import java.util.Formatter;
-import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -32,6 +31,11 @@ public class GameEndpoint {
 
     @OnClose
     public void onClose(Session session) {
+        try {
+            DataCenter.getInstance().logout(session);
+        } catch (LogicException e) {
+            //TODO: log this once we have it set up
+        }
         ClientPortal.getInstance().removeClient(session);
     }
 

--- a/Server/src/server/GameEndpoint.java
+++ b/Server/src/server/GameEndpoint.java
@@ -31,10 +31,11 @@ public class GameEndpoint {
 
     @OnClose
     public void onClose(Session session) {
+        LOGGER.log(Level.INFO, "Connection closed for client: {0}", session.getId());
         try {
             DataCenter.getInstance().logout(session);
         } catch (LogicException e) {
-            //TODO: log this once we have it set up
+            LOGGER.log(Level.WARNING, "Error on forced logout: {0}", e);
         }
         ClientPortal.getInstance().removeClient(session);
     }

--- a/Server/src/server/GameEndpoint.java
+++ b/Server/src/server/GameEndpoint.java
@@ -35,7 +35,8 @@ public class GameEndpoint {
         try {
             DataCenter.getInstance().logout(session);
         } catch (LogicException e) {
-            LOGGER.log(Level.WARNING, "Error on forced logout: {0}", e);
+            LOGGER.log(Level.WARNING, "Error on forced logout for client: {0}", session.getId());
+            LOGGER.log(Level.WARNING, "Error on forced logout: {0}", e.getMessage());
         }
         ClientPortal.getInstance().removeClient(session);
     }

--- a/Server/src/server/dataCenter/DataCenter.java
+++ b/Server/src/server/dataCenter/DataCenter.java
@@ -18,6 +18,7 @@ import server.exceptions.ServerException;
 import server.gameCenter.GameCenter;
 import shared.models.card.Card;
 
+import javax.websocket.Session;
 import java.io.*;
 import java.util.*;
 
@@ -193,6 +194,13 @@ public class DataCenter extends Thread {
         clients.replace(message.getSender(), null);
         GameServer.serverPrint(message.getSender() + " Is Logged Out.");
         GameServer.addToSendingMessages(Message.makeDoneMessage(message.getSender()));
+    }
+
+    public void logout(Session session) throws LogicException {
+        String id = session.getId();
+        loginCheck(id);
+        forceLogout(id);
+        GameServer.serverPrint(id + " Is Logged Out.");
     }
 
     public void createDeck(Message message) throws LogicException {


### PR DESCRIPTION
This should the logout on some WS disconnects (connection dropped, client crashed, stuff like that).
Still does not work in all cases, but the remaining issues will be covered in the async rework.

One important note is that this implementation acts in the same way as purposeful logout: killing the session and all games. We will need to tackle it once we get to implementing reconnects.