### PR TITLE
Update Shared to 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,4 +16,4 @@ jobs:
         java-package: jdk
         architecture: x64
     - name: Build with Maven
-      run: mvn -B clean package test --file pom.xml
+      run: mvn -B clean test package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.11
+        java-version: 11
         java-package: jdk
         architecture: x64
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.11
-        java-package: jdk+fx
+        java-package: jdk
         architecture: x64
     - name: Build with Maven
       run: mvn -B clean package test --file pom.xml

--- a/Build_exe/readme.md
+++ b/Build_exe/readme.md
@@ -5,7 +5,7 @@
 These instructions assume that you already have:
 
 1) A jar file ready to go with dependancies. (To do that, run 'mvm clean package').
-2) A copy of the 1.11 jre somewhere on your system.
+2) A copy of the Java11 jre somewhere on your system.
 3) Python 3.5+ installed on the computer
 4) The build_exe\Application directory has two empty folders (jre, and Client). If this is not the case, you may wish to run the cleanup script first.
 
@@ -14,7 +14,7 @@ These instructions assume that you already have:
 In:
 	\build_exe\Application\jre 
 
-Copy the jre you want to bundle with this build (We are currently using 1.11). 
+Copy the jre you want to bundle with this build (We are currently using Java11). 
 
 Please note that you should copy the contents of the jre. Ergo: '\build_exe\Application\jre\lib' should be a valid path.
 

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <project.java.version>1.11</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -139,7 +139,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>project-classifier</shadedClassifierName>
-                            <outputFile>target\${build.finalName}-shaded.jar</outputFile>
+                            <outputFile>target\${project.build.finalName}-shaded.jar</outputFile>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>Launcher</mainClass>

--- a/Server/pom.xml
+++ b/Server/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <project.java.version>1.11</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/Shared/pom.xml
+++ b/Shared/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <project.java.version>1.8</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -57,8 +57,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <project.java.version>1.11</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <project.java.version>1.11</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
Shared got missed when I merged from master, this makes it Java 11 too, and switches to the more correct `11` for versions instead of `1.11`.

@Qazzquimby and @Ridleh please test if possible before merging.