### PR TITLE
Implemented a turn timer.

### DIFF
--- a/Client/src/main/java/org/projectcardboard/client/view/battleview/HandBox.java
+++ b/Client/src/main/java/org/projectcardboard/client/view/battleview/HandBox.java
@@ -17,6 +17,7 @@ import org.projectcardboard.client.models.gui.ImageButton;
 import org.projectcardboard.client.models.gui.UIConstants;
 import org.projectcardboard.client.models.message.OnlineGame;
 import org.projectcardboard.client.view.MainMenu;
+// import org.projectcardboard.client.models.gui.TurnTimer;
 
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -27,6 +28,8 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.paint.Color;
 import shared.models.card.Card;
+import java.util.Timer;
+import java.util.TimerTask;
 
 public class HandBox implements PropertyChangeListener {
     private static final Effect DISABLE_BUTTON_EFFECT = new ColorAdjust(0, -1, 0, 0);
@@ -44,7 +47,9 @@ public class HandBox implements PropertyChangeListener {
     private final Image endTurnImageGlow = new Image(this.getClass().getResourceAsStream("/ui/button_end_turn_finished_glow@2x.png"));
     private DefaultLabel endTurnLabel;
     private StackPane endTurnButton;
-
+	private Timer turnTimer = null;
+	private int timerCount = 120;
+	private DefaultLabel timeRemaining = null;
 
     HandBox(BattleScene battleScene, CompressedPlayer player) throws Exception {
         this.battleScene = battleScene;
@@ -76,9 +81,34 @@ public class HandBox implements PropertyChangeListener {
             player.addPropertyChangeListener(this);
             battleScene.getGame().addPropertyChangeListener(this);
         }
-
+		this.runTurnTimer();
         addFinishButton();
     }
+
+	private void runTurnTimer() {
+		if (this.turnTimer != null) {
+			this.turnTimer.cancel();
+			this.timerCount = 120;
+		}
+		this.turnTimer = new Timer();
+		this.turnTimer.scheduleAtFixedRate(new TimerTask() {
+			public void run() {
+				Platform.runLater(() -> {
+					if (timerCount == 0) {
+						turnTimer.cancel();
+						if (timeRemaining != null)
+							handGroup.getChildren().remove(timeRemaining);
+						return;
+					}
+					if (timeRemaining != null)
+							handGroup.getChildren().remove(timeRemaining);
+					timeRemaining = new DefaultLabel(Integer.toString(timerCount), Constants.END_TURN_FONT, Color.WHITE);
+					handGroup.getChildren().add(timeRemaining);
+					timerCount--;
+				});
+			}
+		}, 0, 1000);
+	}
 
     private void updateNext() {
         next.getChildren().clear();
@@ -279,13 +309,14 @@ public class HandBox implements PropertyChangeListener {
                     Platform.runLater(() -> {
                         endTurnButton.setEffect(DISABLE_BUTTON_EFFECT);
                         endTurnLabel.setText("ENEMY TURN");
-
+						this.runTurnTimer();
                     });
                 } else {
                     Platform.runLater(() -> {
                         updateNext();
                         endTurnButton.setEffect(null);
                         endTurnLabel.setText("END TURN");
+						this.runTurnTimer();
                     });
                 }
                 break;


### PR DESCRIPTION
The turn timer is instantiated in Handbox, and restarts to 120 whenever a turn ends.
This implementation is fairly dumb, because at first I wanted a separate object which would run a timertask,
but I stumbled upon a problem, because having javafx object separated within multiple threads isn't working, so
I had to put everything back into Handbox source file. For now it works, and we can already try to improve by having multiple display options (circle, bar, dot).