### PR TITLE
Make jfile chooser default to exported decks folder

### DIFF
--- a/Client/src/main/java/org/projectcardboard/client/Constants.java
+++ b/Client/src/main/java/org/projectcardboard/client/Constants.java
@@ -1,0 +1,7 @@
+package org.projectcardboard.client;
+
+public class Constants {
+
+    // Deck building
+    public static final String DECK_EXPORT_FOLDER = "exported_decks";
+}

--- a/Client/src/main/java/org/projectcardboard/client/models/card/DeckExporter.java
+++ b/Client/src/main/java/org/projectcardboard/client/models/card/DeckExporter.java
@@ -4,10 +4,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import org.projectcardboard.client.Constants;
 import org.projectcardboard.client.models.JsonConverter;
 
 public class DeckExporter {
-    private static final String DIRECTORY_NAME = "exported_decks";
+    private static final String DIRECTORY_NAME = Constants.DECK_EXPORT_FOLDER;
     private static final String FORMAT = ".deck.json";
     private final ExportedDeck deck;
 

--- a/Client/src/main/java/org/projectcardboard/client/view/CollectionMenu.java
+++ b/Client/src/main/java/org/projectcardboard/client/view/CollectionMenu.java
@@ -1,6 +1,7 @@
 package org.projectcardboard.client.view;
 
 import com.google.gson.Gson;
+import org.projectcardboard.client.Constants;
 import org.projectcardboard.client.controller.Client;
 import org.projectcardboard.client.controller.CollectionMenuController;
 import org.projectcardboard.client.controller.GraphicalUserInterface;
@@ -26,6 +27,10 @@ import javax.swing.filechooser.FileSystemView;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.*;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.projectcardboard.client.models.gui.UIConstants.*;
 
@@ -135,7 +140,12 @@ public class CollectionMenu extends Show implements PropertyChangeListener {
     }
 
     private String showJFileChooserDialog() {
-        JFileChooser jfc = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
+
+        // Use the directory most likely to contain decks.
+        Path exported_decks = Paths.get("./" + Constants.DECK_EXPORT_FOLDER).toAbsolutePath();
+        String directory = Files.exists(exported_decks) ? exported_decks.toString() : Paths.get("").toAbsolutePath().toString();
+
+        JFileChooser jfc = new JFileChooser(directory);
 
         GraphicalUserInterface.getInstance().closeFullscreen();
 


### PR DESCRIPTION
When importing decks, jfilechooser will default to the place where you most like saved your decks too (i.e exported_decks folder). 

Tested with both the "release" file structure and the "dev" file structure.