### PR TITLE
Add Support To Left/Right Click Cards To Add/Remove Cards From Your Deck

### DIFF
--- a/Client/src/main/java/org/projectcardboard/client/models/gui/DeckCardsGrid.java
+++ b/Client/src/main/java/org/projectcardboard/client/models/gui/DeckCardsGrid.java
@@ -34,16 +34,14 @@ public class DeckCardsGrid extends GridPane {
       DeckCardPane cardPane = new DeckCardPane(card, deck);
       cardPane.setOnMouseClicked(mouseEvent -> {
         MouseButton button = mouseEvent.getButton();
-        if(button.equals(MouseButton.PRIMARY)){
-          CollectionMenuController.getInstance().addCardToDeck(cardPane.getDeck(),
-            card.getName());
-        }
-        else if(button.equals(MouseButton.SECONDARY)){
-          CollectionMenuController.getInstance()
-            .removeCardFromDeck(cardPane.getDeck(), card.getName());
+        if (button.equals(MouseButton.PRIMARY)) {
+          CollectionMenuController.getInstance().addCardToDeck(cardPane.getDeck(), card.getName());
+        } else if (button.equals(MouseButton.SECONDARY)) {
+          CollectionMenuController.getInstance().removeCardFromDeck(cardPane.getDeck(),
+              card.getName());
         }
       });
-      
+
       deckCardBox.getChildren().addAll(cardPane);
 
       add(deckCardBox, i % COLUMN_NUMBER, i / COLUMN_NUMBER);

--- a/Client/src/main/java/org/projectcardboard/client/models/gui/DeckCardsGrid.java
+++ b/Client/src/main/java/org/projectcardboard/client/models/gui/DeckCardsGrid.java
@@ -1,5 +1,6 @@
 package org.projectcardboard.client.models.gui;
 
+import javafx.scene.input.MouseButton;
 import org.projectcardboard.client.controller.CollectionMenuController;
 import javafx.geometry.Pos;
 import javafx.scene.layout.GridPane;
@@ -31,19 +32,19 @@ public class DeckCardsGrid extends GridPane {
       deckCardBox.setAlignment(Pos.CENTER);
 
       DeckCardPane cardPane = new DeckCardPane(card, deck);
-
-      HBox buttonsBox =
-          new HBox(UIConstants.DEFAULT_SPACING,
-              new OrangeButton("ADD",
-                  event -> CollectionMenuController.getInstance().addCardToDeck(cardPane.getDeck(),
-                      card.getName()),
-                  select, false),
-              new OrangeButton("REMOVE", event -> CollectionMenuController.getInstance()
-                  .removeCardFromDeck(cardPane.getDeck(), card.getName()), select, false));
-
-      buttonsBox.setMaxWidth(BUTTONS_WIDTH);
-
-      deckCardBox.getChildren().addAll(cardPane, buttonsBox);
+      cardPane.setOnMouseClicked(mouseEvent -> {
+        MouseButton button = mouseEvent.getButton();
+        if(button.equals(MouseButton.PRIMARY)){
+          CollectionMenuController.getInstance().addCardToDeck(cardPane.getDeck(),
+            card.getName());
+        }
+        else if(button.equals(MouseButton.SECONDARY)){
+          CollectionMenuController.getInstance()
+            .removeCardFromDeck(cardPane.getDeck(), card.getName());
+        }
+      });
+      
+      deckCardBox.getChildren().addAll(cardPane);
 
       add(deckCardBox, i % COLUMN_NUMBER, i / COLUMN_NUMBER);
     }


### PR DESCRIPTION
Part of the larger "Revamp collection screen" epic
this PR allows users to add and remove cards from their deck by left and right clicking respectively. the "ADD" and "REMOVE" buttons have been removed as well 

Its important to note that clicking on the edit icon a second time does not close the edit deck screen for you, so someone may accidentally add or remove a card to their deck. You must click on the back button at the top of the screen. 

I suspect a major drawback to this PR is that it may give users the idea they can triple click a card to add it to their deck. sadly we still send each individual card up to the server and wait for the server's response, so there is noticeable delay between clicking on a card and having it added to your deck (maybe that is me. I am in the US, maser's servers is in Russia) 