### PR TITLE
Update CardAnimation.java

### DIFF
--- a/Client/src/main/java/org/projectcardboard/client/view/battleview/CardAnimation.java
+++ b/Client/src/main/java/org/projectcardboard/client/view/battleview/CardAnimation.java
@@ -54,7 +54,7 @@ public class CardAnimation extends Transition {
     String path;
     if (CardType.SPELL.equals(card.getType())) {
       path =
-          card.isCustom() ? Config.getInstance().getCustomCardsPath().toString() + "/" : "/icons/";
+          card.isCustom() ? Config.getInstance().getCustomCardSpritesPath().toString() + "/" : "/icons/";
     } else {
       path = card.isCustom() ? Config.getInstance().getCustomCardSpritesPath().toString() + "/"
           : "/troopAnimations/";

--- a/Client/src/main/java/org/projectcardboard/client/view/battleview/CardAnimation.java
+++ b/Client/src/main/java/org/projectcardboard/client/view/battleview/CardAnimation.java
@@ -53,8 +53,8 @@ public class CardAnimation extends Transition {
 
     String path;
     if (CardType.SPELL.equals(card.getType())) {
-      path =
-          card.isCustom() ? Config.getInstance().getCustomCardSpritesPath().toString() + "/" : "/icons/";
+      path = card.isCustom() ? Config.getInstance().getCustomCardSpritesPath().toString() + "/"
+          : "/icons/";
     } else {
       path = card.isCustom() ? Config.getInstance().getCustomCardSpritesPath().toString() + "/"
           : "/troopAnimations/";


### PR DESCRIPTION
There is currently a bug relating to custom spell cards. If a custom card is a spell card, we return the path to the CUSTOM_CARDS folder directory, not the CUSTOM_CARDS_SPRITES folder directory, where the relevant pngs and plists are contained. 